### PR TITLE
agregar telefono a base shopify

### DIFF
--- a/client/src/Services/answers.js
+++ b/client/src/Services/answers.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: process.env.REACT_APP_BACKEND_URL,
+  // baseURL: process.env.REACT_APP_BACKEND_URL,
+  baseURL: "http://localhost:5000",
   withCredentials: true
 });
 

--- a/routes/customers.js
+++ b/routes/customers.js
@@ -7,8 +7,7 @@ const axios = require('axios');
 // Ruta get para un usuario con el mail
 router.get('/getCustomer', async (req, res, next) => {
     const email = req.query.email;
-    const phone = req.query.phone;
-    console.log(phone);
+    const phone = req.query.phone === 'false' ? false : req.query.phone;
     const name = req.query.name;
     const reco = req.query.reco;
     const answers = JSON.parse(req.query.answers);
@@ -24,11 +23,23 @@ router.get('/getCustomer', async (req, res, next) => {
                     "tags": tags,
                     "accepts_marketing": true,
                     "marketing_opt_in_level": "single_opt_in",
-                    ...(!phone && { "phone": phone })
+                    ...(phone && { "phone": phone })
                 }
             });
+
             res.json({ success: true, type: "update", user: user.data.customers });
         } else {
+            console.log({
+                "customer": {
+                    "first_name": name,
+                    "email": email,
+                    "answers": answers,
+                    "tags": tags,
+                    "accepts_marketing": true,
+                    "marketing_opt_in_level": "single_opt_in",
+                    ...(phone && { "phone": phone })
+                }
+            });
             const response = await axios.post(`https://${process.env.API_CUSTOMER_KEY}:${process.env.API_CUSTOMER_SECRET}@asana-cup.myshopify.com/admin/api/2021-04/customers.json`, {
                 "customer": {
                     "first_name": name,
@@ -37,7 +48,7 @@ router.get('/getCustomer', async (req, res, next) => {
                     "tags": tags,
                     "accepts_marketing": true,
                     "marketing_opt_in_level": "single_opt_in",
-                    ...(!phone && { "phone": phone })
+                    ...(phone && { "phone": phone })
                 }
             });
             res.json({ success: true, type: "update", user: user.data.customers });

--- a/routes/customers.js
+++ b/routes/customers.js
@@ -8,40 +8,43 @@ const axios = require('axios');
 router.get('/getCustomer', async (req, res, next) => {
     const email = req.query.email;
     const phone = req.query.phone;
+    console.log(phone);
     const name = req.query.name;
     const reco = req.query.reco;
     const answers = JSON.parse(req.query.answers);
-    const tags = answers.reduce((acc,val,index)=> acc+=`${val.tag},`,"")+reco;
+    const tags = answers.reduce((acc, val, index) => acc += `${val.tag},`, "") + reco;
     let id;
     try {
         const user = await axios.get(`https://${process.env.API_CUSTOMER_KEY}:${process.env.API_CUSTOMER_SECRET}@asana-cup.myshopify.com/admin/api/2021-04/customers/search.json?query=email:${email}&fields=email,id`);
         if (user.data.customers.length) {
             id = user.data.customers[0].id;
-            const response = await axios.put(`https://${process.env.API_CUSTOMER_KEY}:${process.env.API_CUSTOMER_SECRET}@asana-cup.myshopify.com/admin/api/2021-04/customers/${id}.json`,{
+            const response = await axios.put(`https://${process.env.API_CUSTOMER_KEY}:${process.env.API_CUSTOMER_SECRET}@asana-cup.myshopify.com/admin/api/2021-04/customers/${id}.json`, {
                 "customer": {
                     "id": id,
                     "tags": tags,
                     "accepts_marketing": true,
-                    "marketing_opt_in_level": "single_opt_in"
+                    "marketing_opt_in_level": "single_opt_in",
+                    ...(!phone && { "phone": phone })
                 }
             });
-            res.json({success:true, type: "update" ,user:user.data.customers });
+            res.json({ success: true, type: "update", user: user.data.customers });
         } else {
-            const response = await axios.post(`https://${process.env.API_CUSTOMER_KEY}:${process.env.API_CUSTOMER_SECRET}@asana-cup.myshopify.com/admin/api/2021-04/customers.json`,{
+            const response = await axios.post(`https://${process.env.API_CUSTOMER_KEY}:${process.env.API_CUSTOMER_SECRET}@asana-cup.myshopify.com/admin/api/2021-04/customers.json`, {
                 "customer": {
                     "first_name": name,
                     "email": email,
-                    "answers":answers,
-                    "tags":tags,
+                    "answers": answers,
+                    "tags": tags,
                     "accepts_marketing": true,
-                    "marketing_opt_in_level": "single_opt_in"
-                  }                 
+                    "marketing_opt_in_level": "single_opt_in",
+                    ...(!phone && { "phone": phone })
+                }
             });
-            res.json({success:true, type: "update" ,user:user.data.customers });
+            res.json({ success: true, type: "update", user: user.data.customers });
         }
     } catch (error) {
         res.json({ success: false, error: { message: error.message } }).status(500);
     }
-  });
+});
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,7 +6,7 @@ const router = new Router();
 const nodemailer = require('nodemailer');
 const hbs = require('nodemailer-express-handlebars');
 const telFunct = require('../helpers/phone-check');
-const {tagGenerator} = require('../helpers/tag-gen');
+const { tagGenerator } = require('../helpers/tag-gen');
 
 const transporter = nodemailer.createTransport({
   service: 'Gmail',
@@ -34,9 +34,9 @@ router.post('/answers', async (req, res, next) => {
   //Phone comes as string.
   let usePhone;
   if (phone) {
-    if (phone.toString().charAt(0)==="1" && phone.toString().charAt(1)==="5") {
+    if (phone.toString().charAt(0) === "1" && phone.toString().charAt(1) === "5") {
       usePhone = phone.toString().split("");
-      usePhone[1]="1";
+      usePhone[1] = "1";
       usePhone = usePhone.join("");
     } else {
       usePhone = phone;
@@ -46,37 +46,37 @@ router.post('/answers', async (req, res, next) => {
   const phoneData = telFunct.telefono(usePhone);
   const workingPhone = phoneData ? phoneData.area_code + phoneData.number : phone;
   try {
-      const a = await Answers.create({ email, name, phone: workingPhone, answers, reco: reco.name }); 
-      const sendName = name.trim().split(' ')[0];
-      const sendNameCapital = sendName.charAt(0).toUpperCase() + sendName.slice(1);
-      if (phoneData) {
-        await transporter.sendMail({
-          from: `Asana Copa Menstrual <${process.env.MAIL}>`,
-          to: email,
-          subject: 'Tu modelo ideal y un regalito 🎁 para vos',
-          template: 'main',
-          context: {
-            name: sendNameCapital,
-            answers,
-            reco,
-            phone: phoneData ? phoneData.area_code + phoneData.number : ""
-          }
-        });
-      } else {
-        await transporter.sendMail({
-          from: `Asana Copa Menstrual <${process.env.MAIL}>`,
-          to: email,
-          subject: 'Tu copita ideal y un regalito 🎁 para vos',
-          template: 'main',
-          context: {
-            name: sendNameCapital,
-            answers,
-            reco,
-            phone: phoneData ? phoneData.area_code + phoneData.number : ""
-          }
-        });
-      }
-      res.redirect(`${process.env.BACK_END_URL}/customers/getCustomer?email=${email}&phone=${phoneData}&name=${name}&reco=${tagGenerator(reco.name)}&answers=${JSON.stringify(answers)}`);
+    const a = await Answers.create({ email, name, phone: workingPhone, answers, reco: reco.name });
+    const sendName = name.trim().split(' ')[0];
+    const sendNameCapital = sendName.charAt(0).toUpperCase() + sendName.slice(1);
+    if (phoneData) {
+      await transporter.sendMail({
+        from: `Asana Copa Menstrual <${process.env.MAIL}>`,
+        to: email,
+        subject: 'Tu modelo ideal y un regalito 🎁 para vos',
+        template: 'main',
+        context: {
+          name: sendNameCapital,
+          answers,
+          reco,
+          phone: phoneData
+        }
+      });
+    } else {
+      await transporter.sendMail({
+        from: `Asana Copa Menstrual <${process.env.MAIL}>`,
+        to: email,
+        subject: 'Tu copita ideal y un regalito 🎁 para vos',
+        template: 'main',
+        context: {
+          name: sendNameCapital,
+          answers,
+          reco,
+          phone: phoneData
+        }
+      });
+    }
+    res.redirect(`${process.env.BACK_END_URL}/customers/getCustomer?email=${email}&phone=${phoneData ? workingPhone : false}&name=${name}&reco=${tagGenerator(reco.name)}&answers=${JSON.stringify(answers)}`);
   } catch (error) {
     res.json({ success: false, error: { message: error.message } }).status(500);
   }
@@ -86,8 +86,8 @@ router.post('/answers-anon', async (req, res, next) => {
   const { answers, reco } = req.body;
 
   try {
-      const a = await Answers.create({ email:"anonymous", name:"anonymous", answers, reco: reco.name }); 
-      res.json({ success: true });
+    const a = await Answers.create({ email: "anonymous", name: "anonymous", answers, reco: reco.name });
+    res.json({ success: true });
   } catch (error) {
     res.json({ success: false, error: { message: error.message } }).status(500);
   }


### PR DESCRIPTION
This PR solves #2 

La forma de solucionarlo fue mediante:

1. Agregar el teléfono formateado al slug del post request para hacer el update/creación del usuario en shopify.
```
res.redirect(`${process.env.BACK_END_URL}/customers/getCustomer?email=${email}&phone=${phoneData ? workingPhone : false}&name=${name}&reco=${tagGenerator(reco.name)}&answers=${JSON.stringify(answers)}`);
```
2. Condicionalmente agregar el campo telefono si efectivamente este fue ingresado por el usuario.
```
                "customer": {
                    "id": id,
                    "tags": tags,
                    "accepts_marketing": true,
                    "marketing_opt_in_level": "single_opt_in",
                    ...(!phone && { "phone": phone })
                }
            });
```

---EDIT---
Para el punto dos la lógica es:
```
                "customer": {
                    "id": id,
                    "tags": tags,
                    "accepts_marketing": true,
                    "marketing_opt_in_level": "single_opt_in",
                    ...(phone && { "phone": phone })
                }
            });
```
Y se le agregó a la definición del teléfono:
```
    const phone = req.query.phone === 'false' ? false : req.query.phone;

```
