### PR TITLE
phone fix

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -80,8 +80,8 @@ function App() {
         if (response.error.message.includes('Daily user sending quota exceeded')) {
           setQuestion('result');
         } else {
-          // setQuestion('result');
-          setError(true);
+          setQuestion('result');
+          // setError(true);
         }
       }
     } catch (error) {

--- a/routes/customers.js
+++ b/routes/customers.js
@@ -7,12 +7,15 @@ const axios = require('axios');
 // Ruta get para un usuario con el mail
 router.get('/getCustomer', async (req, res, next) => {
     const email = req.query.email;
-    const phone = req.query.phone === 'false' ? false : req.query.phone;
+    const phone = req.query.phone;
     const name = req.query.name;
     const reco = req.query.reco;
     const answers = JSON.parse(req.query.answers);
     const tags = answers.reduce((acc, val, index) => acc += `${val.tag},`, "") + reco;
     let id;
+
+    console.log(name, email,phone,reco,answers,tags);
+
     try {
         const user = await axios.get(`https://${process.env.API_CUSTOMER_KEY}:${process.env.API_CUSTOMER_SECRET}@asana-cup.myshopify.com/admin/api/2021-04/customers/search.json?query=email:${email}&fields=email,id`);
         if (user.data.customers.length) {
@@ -23,10 +26,9 @@ router.get('/getCustomer', async (req, res, next) => {
                     "tags": tags,
                     "accepts_marketing": true,
                     "marketing_opt_in_level": "single_opt_in",
-                    ...(phone && { "phone": phone })
+                    "phone": phone
                 }
             });
-
             res.json({ success: true, type: "update", user: user.data.customers });
         } else {
             console.log({
@@ -40,6 +42,7 @@ router.get('/getCustomer', async (req, res, next) => {
                     ...(phone && { "phone": phone })
                 }
             });
+            console.log("phone",phone);
             const response = await axios.post(`https://${process.env.API_CUSTOMER_KEY}:${process.env.API_CUSTOMER_SECRET}@asana-cup.myshopify.com/admin/api/2021-04/customers.json`, {
                 "customer": {
                     "first_name": name,
@@ -48,7 +51,7 @@ router.get('/getCustomer', async (req, res, next) => {
                     "tags": tags,
                     "accepts_marketing": true,
                     "marketing_opt_in_level": "single_opt_in",
-                    ...(phone && { "phone": phone })
+                    "phone": phone
                 }
             });
             res.json({ success: true, type: "update", user: user.data.customers });

--- a/routes/index.js
+++ b/routes/index.js
@@ -31,8 +31,10 @@ router.get('/answers', (req, res, next) => {
 router.post('/answers', async (req, res, next) => {
   const { answers, reco } = req.body;
   const { email, name, phone } = req.body.userInfo;
+
   //Phone comes as string.
   let usePhone;
+  console.log("phone",phone);
   if (phone) {
     if (phone.toString().charAt(0) === "1" && phone.toString().charAt(1) === "5") {
       usePhone = phone.toString().split("");
@@ -62,6 +64,7 @@ router.post('/answers', async (req, res, next) => {
           phone: phoneData
         }
       });
+      res.redirect(`${process.env.BACK_END_URL}/customers/getCustomer?email=${email}&phone=${phoneData ? workingPhone : false}&name=${name}&reco=${tagGenerator(reco.name)}&answers=${JSON.stringify(answers)}`);
     } else {
       await transporter.sendMail({
         from: `Asana Copa Menstrual <${process.env.MAIL}>`,
@@ -75,8 +78,8 @@ router.post('/answers', async (req, res, next) => {
           phone: phoneData
         }
       });
+      res.json({ success: true});
     }
-    res.redirect(`${process.env.BACK_END_URL}/customers/getCustomer?email=${email}&phone=${phoneData ? workingPhone : false}&name=${name}&reco=${tagGenerator(reco.name)}&answers=${JSON.stringify(answers)}`);
   } catch (error) {
     res.json({ success: false, error: { message: error.message } }).status(500);
   }


### PR DESCRIPTION
Solves #8 

Shopify API requiere de submitir un teléfono para crear un usuario que sea único y válido según el format [E.164](https://en.wikipedia.org/wiki/E.164). De no ser así, la API devuelve un error.

La solución a esto se hizo:
1. Haciendo que solo se creen clientes si el número está previamente validado por nuestro algoritmo.
2. No mostrando nunca un error en el Front End, sino indicando siempre el resultado del test.